### PR TITLE
Skip enforcement checks unless User model requires a password.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ The following database migration needs to be applied:
 prompt> rails generate migration create_previous_passwords salt:string encrypted_password:string user:references
 ```
 
-Edit the resulting file to disallow null values for the hash and to add indexes for both hash and user_id fields:
+Edit the resulting file to disallow null values for the hash,add indexes for both hash and user_id fields, and to also
+add the timestamp (created_at, updated_at) fields:
 
 ```ruby
 class CreatePreviousPasswords < ActiveRecord::Migration[5.1]

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ prompt> bundle exec rake
 To determine the Ruby on Rails versions supported by this release, run the following commands:
 
 ```bash
-prompt> gem install flay ruby2ruby rubucop rspec
+prompt> gem install flay ruby2ruby rubocop rspec
 prompt> rake test:spec:targets
 
 Available Rails targets: 5.0.6, 5.1.4

--- a/lib/devise/secure_password/models/password_disallows_frequent_changes.rb
+++ b/lib/devise/secure_password/models/password_disallows_frequent_changes.rb
@@ -7,7 +7,7 @@ module Devise
 
       included do
         include ActionView::Helpers::DateHelper
-        validate :validate_password_frequent_change
+        validate :validate_password_frequent_change, if: :password_required?
 
         set_callback(:initialize, :before, :before_resource_initialized)
         set_callback(:initialize, :after, :after_resource_initialized)

--- a/lib/devise/secure_password/models/password_disallows_frequent_reuse.rb
+++ b/lib/devise/secure_password/models/password_disallows_frequent_reuse.rb
@@ -12,7 +12,7 @@ module Devise
                  class_name: 'Devise::Models::PreviousPassword',
                  foreign_key: 'user_id',
                  dependent: :destroy
-        validate :validate_password_frequent_reuse
+        validate :validate_password_frequent_reuse, if: :password_required?
 
         set_callback(:save, :before, :before_resource_saved)
         set_callback(:save, :after, :after_resource_saved, if: :dirty_password?)
@@ -53,6 +53,7 @@ module Devise
       end
 
       def dirty_password?
+        return false unless password_required?
         if Rails.version > '5.1'
           saved_change_to_encrypted_password?
         else

--- a/lib/devise/secure_password/models/password_has_required_content.rb
+++ b/lib/devise/secure_password/models/password_has_required_content.rb
@@ -8,8 +8,8 @@ module Devise
       LENGTH_MAX = 255
 
       included do
-        validate :validate_password_content
-        validate :validate_password_confirmation_content
+        validate :validate_password_content, if: :password_required?
+        validate :validate_password_confirmation_content, if: :password_required?
       end
 
       def validate_password_content

--- a/lib/devise/secure_password/version.rb
+++ b/lib/devise/secure_password/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module SecurePassword
-    VERSION = '1.0.2'.freeze
+    VERSION = '1.0.3'.freeze
   end
 end


### PR DESCRIPTION
This fix skips enforcement checks unless the User model's password_required? method returns truthy.