### PR TITLE
[PLAT-506] devise-secure_password is expiring passwords early

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog: devise-secure_password
 
+## 1.0.6 / 2018-05-04
+
+* Fix scoping for previous passwords returned through associations.
+
 ## 1.0.5 / 2018-04-30
 
 * Update rails-app-5_1_4 config for SQLite3Adapter changes.

--- a/lib/devise/secure_password/models/password_disallows_frequent_changes.rb
+++ b/lib/devise/secure_password/models/password_disallows_frequent_changes.rb
@@ -26,7 +26,7 @@ module Devise
       end
 
       def password_recent?
-        last_password = previous_passwords.unscoped.last
+        last_password = previous_passwords.first
         last_password&.fresh?(self.class.password_minimum_age)
       end
 

--- a/lib/devise/secure_password/models/password_requires_regular_updates.rb
+++ b/lib/devise/secure_password/models/password_requires_regular_updates.rb
@@ -13,7 +13,7 @@ module Devise
       end
 
       def password_expired?
-        last_password = previous_passwords.unscoped.last
+        last_password = previous_passwords.first
         inconsistent_password?(last_password) || last_password.stale?(self.class.password_maximum_age)
       end
 

--- a/lib/devise/secure_password/version.rb
+++ b/lib/devise/secure_password/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module SecurePassword
-    VERSION = '1.0.5'.freeze
+    VERSION = '1.0.6'.freeze
   end
 end

--- a/spec/feature/user_changes_password_spec.rb
+++ b/spec/feature/user_changes_password_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'User changes password', type: :feature do
     let(:new_password) { user.password + 'Z' }
     before do
       user.save
-      last_password = user.previous_passwords.unscoped.last
+      last_password = user.previous_passwords.first
       last_password.created_at = Time.zone.now - 2.days
       last_password.save
       login_as(user, scope: :user)

--- a/spec/feature/user_logs_in_spec.rb
+++ b/spec/feature/user_logs_in_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'User logs in', type: :feature do
   context 'with a password older than password_maximum_age', js: true do
     before do
       user.save
-      last_password = user.previous_passwords.unscoped.last
+      last_password = user.previous_passwords.first
       last_password.created_at = Time.zone.now - User.password_maximum_age
       last_password.save
       visit '/users/sign_in'

--- a/spec/models/password_disallows_frequent_changes_spec.rb
+++ b/spec/models/password_disallows_frequent_changes_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Devise::Models::PasswordDisallowsFrequentChanges, type: :model do
       before do
         user.save
         # reset its previous_password record to one day before
-        last_password = user.previous_passwords.unscoped.last
+        last_password = user.previous_passwords.first
         last_password.created_at = Time.zone.now - Isolated::UserFrequentChanges.password_minimum_age
         last_password.save
         # bypass frequent_reuse validator by changing password
@@ -88,7 +88,7 @@ RSpec.describe Devise::Models::PasswordDisallowsFrequentChanges, type: :model do
       before do
         user.save
         # reset its previous_password record one day past minimum
-        last_password = user.previous_passwords.unscoped.last
+        last_password = user.previous_passwords.first
         last_password.created_at = Time.zone.now - Isolated::UserFrequentChanges.password_minimum_age
         last_password.save
       end

--- a/spec/models/password_disallows_frequent_reuse_spec.rb
+++ b/spec/models/password_disallows_frequent_reuse_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Devise::Models::PasswordDisallowsFrequentReuse, type: :model do
     end
 
     context 'when previous passwords exist' do
-      let(:dates) { (max_count-1).downto(0).to_a.map { |c| c.days.ago } }
+      let(:dates) { (max_count - 1).downto(0).to_a.map { |c| c.days.ago } }
       @last_password = nil
 
       before do

--- a/spec/models/password_requires_regular_updates_spec.rb
+++ b/spec/models/password_requires_regular_updates_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Devise::Models::PasswordRequiresRegularUpdates, type: :model do
       before do
         user.save
         # reset its previous_password record to one day past maximum
-        last_password = user.previous_passwords.unscoped.last
+        last_password = user.previous_passwords.first
         last_password.created_at = Time.zone.now - Isolated::UserRegularUpdates.password_maximum_age
         last_password.save
       end

--- a/spec/models/previous_password_spec.rb
+++ b/spec/models/previous_password_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Devise::Models::PreviousPassword, type: :model do
   describe '#fresh?' do
     it { is_expected.to respond_to(:fresh?) }
 
-    let(:previous_password) { user.previous_passwords.unscoped.last }
+    let(:previous_password) { user.previous_passwords.first }
 
     before { user.save }
 
@@ -86,7 +86,7 @@ RSpec.describe Devise::Models::PreviousPassword, type: :model do
   describe '#stale?' do
     it { is_expected.to respond_to(:stale?) }
 
-    let(:previous_password) { user.previous_passwords.unscoped.last }
+    let(:previous_password) { user.previous_passwords.first }
 
     before { user.save }
 


### PR DESCRIPTION
The *devise-secure_password* gem appears to be expiring passwords earlier than the configured required expiry time. This appears to be an issue with scoping applied when retrieving previous passwords through the User association.