### PR TITLE
Fix default scope for the uuid primary key

### DIFF
--- a/lib/devise/secure_password/models/previous_password.rb
+++ b/lib/devise/secure_password/models/previous_password.rb
@@ -3,7 +3,7 @@ module Devise
     class PreviousPassword < ::ActiveRecord::Base
       self.table_name = 'previous_passwords'
       belongs_to :user
-      default_scope -> { order(id: :desc) }
+      default_scope -> { order(created_at: :desc) }
       validates :user_id, presence: true
       validates :salt, presence: true
       validates :encrypted_password, presence: true


### PR DESCRIPTION
When use primary key as a uuid last password could not be fetch correctly with old default scope. This mr change to default scope id to created_at