### PR TITLE
Support additional special characters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog: devise-secure_password
 
+## 1.1.1 / 2021-12-08
+
+* Implement support to additional special characters. #71
+
 ## 1.1.0 / 2018-08-08
 
 With this release, the __devise-secure_password__ gem drops official support for Rails < 5.1. Supported versions are now

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog: devise-secure_password
 
-## 1.1.1 / 2021-12-08
+## 2.0.2 / 2021-12-08
 
 * Implement support to additional special characters. #71
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Devise.setup do |config|
   # The number of numbers (0-9) required in a password:
   # config.password_required_number_count = 1
 
-  # The number of special characters (!@#$%^&*()_+-=[]{}|') required in a password:
+  # The number of special characters (!@\#$%^&*()_+-=[]{}|'\"/\\^.,`<>:;?~ ) required in a password:
   # config.password_required_special_character_count = 1
 
   # ==> Configuration for the Devise Secure Password extension

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Devise.setup do |config|
   # The number of numbers (0-9) required in a password:
   # config.password_required_number_count = 1
 
-  # The number of special characters (!@\#$%^&*()_+-=[]{}|'"/\^.,`<>:;?~ ) required in a password:
+  # The number of special characters ( !@#$%^&*()_+-=[]{}|'"/\.,`<>:;?~) required in a password:
   # config.password_required_special_character_count = 1
 
   # ==> Configuration for the Devise Secure Password extension

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Devise.setup do |config|
   # The number of numbers (0-9) required in a password:
   # config.password_required_number_count = 1
 
-  # The number of special characters (!@\#$%^&*()_+-=[]{}|'\"/\\^.,`<>:;?~ ) required in a password:
+  # The number of special characters (!@\#$%^&*()_+-=[]{}|'"/\^.,`<>:;?~ ) required in a password:
   # config.password_required_special_character_count = 1
 
   # ==> Configuration for the Devise Secure Password extension

--- a/devise-secure_password.gemspec
+++ b/devise-secure_password.gemspec
@@ -24,6 +24,11 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['./**/*'].reject do |f|
     f.match(%r{^./(test|spec|features|lib/tasks)/|Gemfile.lock.ci})
   end
+
+  spec.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
+
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']

--- a/lib/generators/devise/templates/secure_password.rb
+++ b/lib/generators/devise/templates/secure_password.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # The number of numbers (0-9) required in a password:
   # config.password_required_number_count = 1
 
-  # The number of special characters (!@#$%^&*()_+-=[]{}|') required in a password:
+  # The number of special characters (!@\#$%^&*()_+-=[]{}|'\"/\\^.,`<>:;?~ ) required in a password:
   # config.password_required_special_character_count = 1
 
   # ==> Configuration for the Devise Secure Password extension

--- a/lib/generators/devise/templates/secure_password.rb
+++ b/lib/generators/devise/templates/secure_password.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # The number of numbers (0-9) required in a password:
   # config.password_required_number_count = 1
 
-  # The number of special characters (!@\#$%^&*()_+-=[]{}|'"/\^.,`<>:;?~ ) required in a password:
+  # The number of special characters ( !@#$%^&*()_+-=[]{}|'"/\.,`<>:;?~) required in a password:
   # config.password_required_special_character_count = 1
 
   # ==> Configuration for the Devise Secure Password extension

--- a/lib/generators/devise/templates/secure_password.rb
+++ b/lib/generators/devise/templates/secure_password.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # The number of numbers (0-9) required in a password:
   # config.password_required_number_count = 1
 
-  # The number of special characters (!@\#$%^&*()_+-=[]{}|'\"/\\^.,`<>:;?~ ) required in a password:
+  # The number of special characters (!@\#$%^&*()_+-=[]{}|'"/\^.,`<>:;?~ ) required in a password:
   # config.password_required_special_character_count = 1
 
   # ==> Configuration for the Devise Secure Password extension

--- a/lib/support/string/character_counter.rb
+++ b/lib/support/string/character_counter.rb
@@ -11,7 +11,7 @@ module Support
           uppercase: characters_to_dictionary(('A'..'Z').to_a),
           lowercase: characters_to_dictionary(('a'..'z').to_a),
           number: characters_to_dictionary(('0'..'9').to_a),
-          special: characters_to_dictionary(%w(! @ # $ % ^ & * ( ) _ + - = [ ] { } | ')),
+          special: characters_to_dictionary(['!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '-', '=', '[', ']', '{', '}', '|', '\'', '"', '/', '\\', '^', '.', ',', '`', '<', '>', ':', ';', '?', '~', ' ']),
           unknown: {}
         }
       end

--- a/lib/support/string/character_counter.rb
+++ b/lib/support/string/character_counter.rb
@@ -11,7 +11,7 @@ module Support
           uppercase: characters_to_dictionary(('A'..'Z').to_a),
           lowercase: characters_to_dictionary(('a'..'z').to_a),
           number: characters_to_dictionary(('0'..'9').to_a),
-          special: characters_to_dictionary(%W(\s ! @ # $ % ^ & * ( ) _ + - = [ ] { } | " / \\ ^ . , ` < > : ; ? ~ \')),
+          special: characters_to_dictionary(%W(\s ! @ # $ % ^ & * ( ) _ + - = [ ] { } | " / \\ . , ` < > : ; ? ~ \')),
           unknown: {}
         }
       end

--- a/lib/support/string/character_counter.rb
+++ b/lib/support/string/character_counter.rb
@@ -11,7 +11,7 @@ module Support
           uppercase: characters_to_dictionary(('A'..'Z').to_a),
           lowercase: characters_to_dictionary(('a'..'z').to_a),
           number: characters_to_dictionary(('0'..'9').to_a),
-          special: characters_to_dictionary(%W(\s ! @ # $ % ^ & * ( ) _ + - = [ ] { } | " / \\ . , ` < > : ; ? ~ \')),
+          special: characters_to_dictionary([' ', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '-', '=', '[', ']', '{', '}', '|', '"', '/', '\\', '.', ',', '', '<', '>', ':', ';', '?', '~', "'"]),
           unknown: {}
         }
       end

--- a/lib/support/string/character_counter.rb
+++ b/lib/support/string/character_counter.rb
@@ -11,7 +11,7 @@ module Support
           uppercase: characters_to_dictionary(('A'..'Z').to_a),
           lowercase: characters_to_dictionary(('a'..'z').to_a),
           number: characters_to_dictionary(('0'..'9').to_a),
-          special: characters_to_dictionary(['!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '-', '=', '[', ']', '{', '}', '|', '\'', '"', '/', '\\', '^', '.', ',', '`', '<', '>', ':', ';', '?', '~', ' ']),
+          special: characters_to_dictionary(%W(\s ! @ # $ % ^ & * ( ) _ + - = [ ] { } | " / \\ ^ . , ` < > : ; ? ~ \')),
           unknown: {}
         }
       end

--- a/lib/support/string/character_counter.rb
+++ b/lib/support/string/character_counter.rb
@@ -11,7 +11,7 @@ module Support
           uppercase: characters_to_dictionary(('A'..'Z').to_a),
           lowercase: characters_to_dictionary(('a'..'z').to_a),
           number: characters_to_dictionary(('0'..'9').to_a),
-          special: characters_to_dictionary([' ', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '-', '=', '[', ']', '{', '}', '|', '"', '/', '\\', '.', ',', '', '<', '>', ':', ';', '?', '~', "'"]),
+          special: characters_to_dictionary([' ', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '-', '=', '[', ']', '{', '}', '|', '"', '/', '\\', '.', ',', '`', '<', '>', ':', ';', '?', '~', "'"]),
           unknown: {}
         }
       end

--- a/spec/feature/user_changes_password_spec.rb
+++ b/spec/feature/user_changes_password_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'User changes password', type: :feature do
     let(:uppercase_range) { Regexp.escape('(A..Z)') }
     let(:lowercase_range) { Regexp.escape('(a..z)') }
     let(:numeric_range) { Regexp.escape('(0..9)') }
-    let(:special_range) { Regexp.escape("(!@\#$%^&*()_+-=[]{}|'\"/^.,`<>:;?~ )") }
+    let(:special_range) { Regexp.escape("( !@\#$%^&*()_+-=[]{}|\"/^.,`<>:;?~')") }
 
     context 'when new password is invalid' do
       let(:bad_password) { 'a' * 12 }

--- a/spec/feature/user_changes_password_spec.rb
+++ b/spec/feature/user_changes_password_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'User changes password', type: :feature do
     let(:uppercase_range) { Regexp.escape('(A..Z)') }
     let(:lowercase_range) { Regexp.escape('(a..z)') }
     let(:numeric_range) { Regexp.escape('(0..9)') }
-    let(:special_range) { Regexp.escape("(!@\#$%^&*()_+-=[]{}|')") }
+    let(:special_range) { Regexp.escape("(!@\#$%^&*()_+-=[]{}|'\"/^.,`<>:;?~ )") }
 
     context 'when new password is invalid' do
       let(:bad_password) { 'a' * 12 }

--- a/spec/feature/user_changes_password_spec.rb
+++ b/spec/feature/user_changes_password_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'User changes password', type: :feature do
     let(:uppercase_range) { Regexp.escape('(A..Z)') }
     let(:lowercase_range) { Regexp.escape('(a..z)') }
     let(:numeric_range) { Regexp.escape('(0..9)') }
-    let(:special_range) { Regexp.escape("( !@\#$%^&*()_+-=[]{}|\"/^.,`<>:;?~')") }
+    let(:special_range) { Regexp.escape("( !@\#$%^&*()_+-=[]{}|\"/\\.,`<>:;?~')") }
 
     context 'when new password is invalid' do
       let(:bad_password) { 'a' * 12 }

--- a/spec/libraries/support_string_spec.rb
+++ b/spec/libraries/support_string_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Support::String::CharacterCounter do
   let(:uppercase_chars) { ('A'..'Z').to_a }
   let(:lowercase_chars) { ('a'..'z').to_a }
   let(:number_chars) { ('0'..'9').to_a }
-  let(:special_chars) { %w(! @ # $ % ^ & * ( ) _ + - = [ ] { } | ') }
-  let(:unknown_chars) { %w(:) }
+  let(:special_chars) { %W(\s ! @ # $ % ^ & * ( ) _ + - = [ ] { } | " / \\ ^ . , ` < > : ; ? ~ \') }
+  let(:unknown_chars) { %w(β Γ 𝛾) }
 
   describe 'attributes' do
     it { is_expected.to respond_to(:count_hash) }

--- a/spec/libraries/support_string_spec.rb
+++ b/spec/libraries/support_string_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Support::String::CharacterCounter do
   let(:uppercase_chars) { ('A'..'Z').to_a }
   let(:lowercase_chars) { ('a'..'z').to_a }
   let(:number_chars) { ('0'..'9').to_a }
-  let(:special_chars) { %W(\s ! @ # $ % ^ & * ( ) _ + - = [ ] { } | " / \\ . , ` < > : ; ? ~ \') }
+  let(:special_chars) { [' ', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '-', '=', '[', ']', '{', '}', '|', '"', '/', '\\', '.', ',', '', '<', '>', ':', ';', '?', '~', "'"] }
   let(:unknown_chars) { %w(β) }
 
   describe 'attributes' do

--- a/spec/libraries/support_string_spec.rb
+++ b/spec/libraries/support_string_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Support::String::CharacterCounter do
   let(:lowercase_chars) { ('a'..'z').to_a }
   let(:number_chars) { ('0'..'9').to_a }
   let(:special_chars) { %W(\s ! @ # $ % ^ & * ( ) _ + - = [ ] { } | " / \\ ^ . , ` < > : ; ? ~ \') }
-  let(:unknown_chars) { %w(β Γ 𝛾) }
+  let(:unknown_chars) { %w(β) }
 
   describe 'attributes' do
     it { is_expected.to respond_to(:count_hash) }

--- a/spec/libraries/support_string_spec.rb
+++ b/spec/libraries/support_string_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Support::String::CharacterCounter do
   let(:uppercase_chars) { ('A'..'Z').to_a }
   let(:lowercase_chars) { ('a'..'z').to_a }
   let(:number_chars) { ('0'..'9').to_a }
-  let(:special_chars) { [' ', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '-', '=', '[', ']', '{', '}', '|', '"', '/', '\\', '.', ',', '', '<', '>', ':', ';', '?', '~', "'"] }
+  let(:special_chars) { [' ', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '-', '=', '[', ']', '{', '}', '|', '"', '/', '\\', '.', ',', '`', '<', '>', ':', ';', '?', '~', "'"] }
   let(:unknown_chars) { %w(β) }
 
   describe 'attributes' do

--- a/spec/libraries/support_string_spec.rb
+++ b/spec/libraries/support_string_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Support::String::CharacterCounter do
   let(:uppercase_chars) { ('A'..'Z').to_a }
   let(:lowercase_chars) { ('a'..'z').to_a }
   let(:number_chars) { ('0'..'9').to_a }
-  let(:special_chars) { %W(\s ! @ # $ % ^ & * ( ) _ + - = [ ] { } | " / \\ ^ . , ` < > : ; ? ~ \') }
+  let(:special_chars) { %W(\s ! @ # $ % ^ & * ( ) _ + - = [ ] { } | " / \\ . , ` < > : ; ? ~ \') }
   let(:unknown_chars) { %w(β) }
 
   describe 'attributes' do

--- a/spec/models/password_has_required_content_spec.rb
+++ b/spec/models/password_has_required_content_spec.rb
@@ -76,6 +76,206 @@ RSpec.describe Devise::Models::PasswordHasRequiredContent, type: :model do
       it { is_expected.not_to be_valid }
     end
 
+    context 'when password contains allowed special characters' do
+      context 'with space' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub ' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with exclamation' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub!' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with double quote' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub"' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with number sign (hash)' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub#' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with dollar sign' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub$' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with percent' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub%' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with ampersand (&)' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub&' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with single quote (\')' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub\'' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with left parenthesis' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub(' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with right parenthesis' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub)' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with asterisk' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub*' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with plus' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub+' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with comma' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub,' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with minus' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub-' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with full stop' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub.' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with slash' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub/' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with colon' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub:' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with semicolon' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub;' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with less than sign' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub<' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with equal sign' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub=' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with greater than' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub>' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with question mark' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub?' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with at sign' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub@' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with left bracket' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub[' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with backslash' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub\\' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with right bracket' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub]' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with caret' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub^' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with underscore' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub_' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with grave accent (backtick)' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub`' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with left brace' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub{' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with vertical bar' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub|' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with right brace' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub}' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with tilde' do
+        before { user.password = user.password_confirmation = 'Bubb1234bub~' }
+
+        it { is_expected.to be_valid }
+      end
+    end
+
     context 'when password contains minimum number of required characters' do
       it { is_expected.to be_valid }
     end


### PR DESCRIPTION
Adding support to the extra password special characters listed below:
- space ` `
- double-quote `"` 
- slash `/`
- backslash `\`
- caret `^`
- full stop `.`
- comma `,`
- grave accent ```
- less than `<`
- greater than `>`
- colon `:`
- semicolon `;`
- question mark `?`
- tilde `~`

Reference: https://owasp.org/www-community/password-special-characters