### PR TITLE
bumps sqlite3 development dependency to 1.7.0

### DIFF
--- a/devise-secure_password.gemspec
+++ b/devise-secure_password.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'selenium-webdriver',      '>= 3.7.0'
   spec.add_development_dependency 'simplecov',               '>= 0.18.2'
   spec.add_development_dependency 'simplecov-console',       '>= 0.4.2'
-  spec.add_development_dependency 'sqlite3',                 '>= 1.3.13'
+  spec.add_development_dependency 'sqlite3',                 '>= 1.7.0'
 
   spec.required_ruby_version = '>= 2.7'
 end


### PR DESCRIPTION
There's several errors while trying to compile `sqlite3` previous version `1.3.13` at macOS Sonoma 14.5